### PR TITLE
Feat/cesium entity

### DIFF
--- a/frontend/src/components/EntityPoint.jsx
+++ b/frontend/src/components/EntityPoint.jsx
@@ -1,0 +1,24 @@
+import { Entity, PointGraphics } from 'resium';
+import { Cartesian3 } from 'cesium';
+
+/**
+ * A resuable Resium component that renders a Cesium Entity with PointGraphics
+ * at a fixed geograohic location
+ * @param {Object} props
+ * @param {number} props.longitude - The longitude, in degrees
+ * @param {number} props.latitude - The latitude, in degrees
+ * @param {number} props.height - The height, in meters, above the ellipsoid
+ * @param {number} props.pixelSize - specifies the size in pixels
+ * @returns {JSX.Element} - A Resium Entity configured with PointGraphics
+ */
+
+export const EntityPoint = (entityPoint) => {
+    const { longitude, latitude, height, pixelSize } = entityPoint;
+    const position = Cartesian3.fromDegrees(longitude, latitude, height);
+
+    return (
+        <Entity position={position}>
+            <PointGraphics pixelSize={pixelSize} />
+        </Entity>
+    );
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,10 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'url';
 
-// https://vite.dev/config/
 export default defineConfig({
     plugins: [react()],
     define: {
         CESIUM_BASE_URL: JSON.stringify('/cesium/'),
+    },
+    resolve: {
+        alias: {
+            '@components': fileURLToPath(
+                new URL('./src/components', import.meta.url)
+            ),
+        },
     },
 });


### PR DESCRIPTION
## Summary

Adds a reusable map point component that renders geospatial points (longitude, latitude, height) on the Cesium globe.

This abstracts Cesium entity creation and improves reusability across the application.

## Changes 
- Added documented `Entity` component (JSDoc)
- Configured Vite path alias for `@components`

## Testing

Manually verified by rendering the `Entity` component in `App.js`
and confirming correct positioning on the Cesium globe.

fixes: Issue #4