### PR TITLE
docs: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Report a new Bug
+labels: ['bug']
+assignees: ['alexhalcazar']
+type: bug
+body:
+    - type: input
+      id: description
+      attributes:
+          label: Description
+          placeholder: Short description of the bug
+      validations:
+          required: true
+    - type: textarea
+      id: steps
+      attributes:
+          label: Steps to reproduce
+          placeholder: Describe the steps that produce the bug
+      validations:
+          required: true
+    - type: textarea
+      id: expected
+      attributes:
+          label: Expected behavior
+          placeholder: What is the expected behavior?
+      validations:
+          required: true
+    - type: textarea
+      id: actual
+      attributes:
+          label: Actual behavior
+          placeholder: What is the actual behavior caused by the bug?
+      validations:
+          required: true
+    - type: textarea
+      id: screenshots
+      attributes:
+          label: Screenshots
+          description: If applicable, add screenshots to help explain your problem

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Submit a new feature request
+labels: ['enhancement']
+assignees: ['alexhalcazar']
+type: feature
+body:
+    - type: dropdown
+      id: role
+      attributes:
+          label: As a...
+          options:
+              - Admin
+              - Developer
+              - User
+      validations:
+          required: true
+    - type: input
+      id: goal
+      attributes:
+          label: I want to...
+          placeholder: Describe the feature
+      validations:
+          required: true
+    - type: textarea
+      id: reason
+      attributes:
+          label: So that...
+          placeholder: Explain the benefit or problem it solves
+      validations:
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Context
+
+Why is this change neccessary?  
+What problem does it solve?
+
+## Summary
+
+Provide a short overview of the changes introduced in this PR.
+
+## Changes
+
+- New functionality:
+- Modifications:
+- Refactoring:
+- External dependencies updated:
+
+## Testing
+
+Describe how this change was tested. Include:
+
+- Manual testing steps
+- Automated test coverage
+- Edge cases considered
+
+## Related Issue
+
+Closes #
+
+## Checklist
+
+- [ ] Tests added or updated (if applicable)
+- [ ] Documentation updated (if applicable)
+- [ ] No breaking changes introduced
+- [ ] Linked related issue


### PR DESCRIPTION
## Context

Introduce GitHub issue and PR templates to standardize contributions and maintain consistency across the repository.

## Summary

Added a feature request template, bug report template, and pull request template to improve contribution workflow.

## Changes

- Feature template added
- Bug template added
- Pull Request template added

## Testing

This PR must first be merged into CommandSat default branch in order to verify working templates

## Related Issue 

None