### PR TITLE
chore(prettierrc): add YAML tabwidth override

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -4,36 +4,36 @@ labels: ['bug']
 assignees: ['alexhalcazar']
 type: bug
 body:
-    - type: input
-      id: description
-      attributes:
-          label: Description
-          placeholder: Short description of the bug
-      validations:
-          required: true
-    - type: textarea
-      id: steps
-      attributes:
-          label: Steps to reproduce
-          placeholder: Describe the steps that produce the bug
-      validations:
-          required: true
-    - type: textarea
-      id: expected
-      attributes:
-          label: Expected behavior
-          placeholder: What is the expected behavior?
-      validations:
-          required: true
-    - type: textarea
-      id: actual
-      attributes:
-          label: Actual behavior
-          placeholder: What is the actual behavior caused by the bug?
-      validations:
-          required: true
-    - type: textarea
-      id: screenshots
-      attributes:
-          label: Screenshots
-          description: If applicable, add screenshots to help explain your problem
+  - type: input
+    id: description
+    attributes:
+      label: Description
+      placeholder: Short description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: Describe the steps that produce the bug
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What is the expected behavior?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What is the actual behavior caused by the bug?
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -4,27 +4,27 @@ labels: ['enhancement']
 assignees: ['alexhalcazar']
 type: feature
 body:
-    - type: dropdown
-      id: role
-      attributes:
-          label: As a...
-          options:
-              - Admin
-              - Developer
-              - User
-      validations:
-          required: true
-    - type: input
-      id: goal
-      attributes:
-          label: I want to...
-          placeholder: Describe the feature
-      validations:
-          required: true
-    - type: textarea
-      id: reason
-      attributes:
-          label: So that...
-          placeholder: Explain the benefit or problem it solves
-      validations:
-          required: true
+  - type: dropdown
+    id: role
+    attributes:
+      label: As a...
+      options:
+        - Admin
+        - Developer
+        - User
+    validations:
+      required: true
+  - type: input
+    id: goal
+    attributes:
+      label: I want to...
+      placeholder: Describe the feature
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: So that...
+      placeholder: Explain the benefit or problem it solves
+    validations:
+      required: true

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,13 @@
     "trailingComma": "es5",
     "tabWidth": 4,
     "singleQuote": true,
-    "jsxSingleQuote": true
+    "jsxSingleQuote": true,
+    "overrides": [
+        {
+            "files": "**/*.yml",
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
 }


### PR DESCRIPTION
## Context

Recently created issue templates are currently not registering on Github
This PR hopes to solve this issue

## Summary

This PR adds on override attribute to the prettierrc config file, maintaining 2 width tabs for YAML files

## Changes

- Prettierrc config file: added override attribute YAML

## Testing

Testing needs to be done after merging this PR to ensure issue templates are now registering

## Related Issue

N/A

## Checklist

- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [X] No breaking changes introduced
- [ ] Linked related issue
