### PR TITLE
Feat/default gcs

### DIFF
--- a/backend/api/config/redisClient.js
+++ b/backend/api/config/redisClient.js
@@ -16,11 +16,18 @@ export const redisClient = createClient({
 
 export const subscriber = redisClient.duplicate();
 
-(async () => {
+redisClient.on('error', (err) => {
+    console.error('Redis Client Error:', err);
+});
+subscriber.on('error', (err) => {
+    console.error('Redis Subscriber Error:', err);
+});
+
+export const connectRedis = async () => {
     try {
         await redisClient.connect();
         await subscriber.connect();
     } catch (err) {
         console.log(err);
     }
-})();
+};

--- a/backend/api/config/wsHandler.js
+++ b/backend/api/config/wsHandler.js
@@ -5,9 +5,9 @@ import { WebSocket } from 'ws';
 export const startRedisListener = async () => {
     try {
         await subscriber.subscribe('user-updates', (message) => {
-            const { userId, type, data } = JSON.parse(message);
+            const { user_id, type, data } = JSON.parse(message);
             // Look up the right WebSocket client
-            const ws = getClient(userId);
+            const ws = getClient(user_id);
 
             if (ws && ws.readyState === WebSocket.OPEN) {
                 ws.send(JSON.stringify({ type, data }));

--- a/backend/api/controllers/satellites.controller.js
+++ b/backend/api/controllers/satellites.controller.js
@@ -1,9 +1,9 @@
 import { pushJob } from '#services/satellites.service';
 
 export const pushSatelliteJob = async (req, res) => {
-    const { userId, gcs } = req.body;
+    const { user_id, gcs } = req.body;
     try {
-        await pushJob(userId, gcs);
+        await pushJob(user_id, gcs);
         res.json({ message: 'queued' });
     } catch (err) {
         console.log(err);

--- a/backend/api/services/satellites.service.js
+++ b/backend/api/services/satellites.service.js
@@ -1,11 +1,11 @@
 import { redisClient } from '../config/redisClient.js';
 
-export const pushJob = async (userId, gcs) => {
+export const pushJob = async (user_id, gcs) => {
     try {
         await redisClient.lPush(
             'satellite_jobs',
             JSON.stringify({
-                userId,
+                user_id,
                 gcs,
             })
         );

--- a/backend/app.js
+++ b/backend/app.js
@@ -5,8 +5,9 @@ import auth from '#routes/auth';
 import authMiddleware from './api/middleware/jwt.js';
 import http from 'http';
 import { WebSocketServer } from 'ws';
-import { addClient, removeClient } from './api/config/wsManager.js';
+import { addClient, getClient, removeClient } from './api/config/wsManager.js';
 import { startRedisListener } from './api/config/wsHandler.js';
+import { connectRedis } from './api/config/redisClient.js';
 
 const app = express();
 const port = 3000;
@@ -17,6 +18,7 @@ const wss = new WebSocketServer({ server });
 
 (async () => {
     try {
+        await connectRedis();
         await startRedisListener();
         console.log('Redis listener started');
     } catch (err) {
@@ -28,12 +30,14 @@ const wss = new WebSocketServer({ server });
 wss.on('connection', (socket, request) => {
     console.log('Client connected!');
     const params = new URLSearchParams(request.url.split('?')[1]);
-    const userId = params.get('userId');
+    const userId = params.get('user_id');
 
     addClient(userId, socket);
 
     socket.on('close', () => {
-        removeClient(userId);
+        if (getClient(userId) === socket) {
+            removeClient(userId);
+        }
     });
 });
 

--- a/backend/python_scripts/worker.py
+++ b/backend/python_scripts/worker.py
@@ -45,8 +45,7 @@ def process_jobs(r):
             print('We got a new job!')
             _, data = job
             payload = json.loads(data)
-
-            user_id = payload['userId']
+            user_id = payload['user_id']
             satellites = []
             for gcs in payload['gcs']:
                 lat = gcs['lat']
@@ -54,10 +53,10 @@ def process_jobs(r):
                 alt = gcs['alt']
                 gcs_satellites =  fetch_satellites_above(lat, lng, alt)
                 satellites.extend(gcs_satellites['above'])
-            
+
             print('publishing data')
             r.publish('user-updates', json.dumps({
-                'userId': str(user_id),
+                'user_id': str(user_id),
                 'type': 'satellite_data',
                 'data': satellites
             }))

--- a/backend/tests/services/satelliteJobs.test.js
+++ b/backend/tests/services/satelliteJobs.test.js
@@ -15,15 +15,15 @@ describe('pushJob', () => {
     });
 
     it('should enqueue a job into Redis with correct payload', async () => {
-        const userId = 'user123';
+        const user_id = 'user123';
         const gcs = { lat: 34.05, lng: -118.25 };
 
-        await pushJob(userId, gcs);
+        await pushJob(user_id, gcs);
 
         expect(redisClient.lPush).toHaveBeenCalledTimes(1);
         expect(redisClient.lPush).toHaveBeenCalledWith(
             'satellite_jobs',
-            JSON.stringify({ userId, gcs })
+            JSON.stringify({ user_id, gcs })
         );
     });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "axios": "^1.16.0",
                 "cesium": "^1.138.0",
+                "jwt-decode": "^4.0.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
                 "react-router-dom": "^7.15.0",
@@ -2550,6 +2551,15 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/kdbush": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "axios": "^1.16.0",
         "cesium": "^1.138.0",
+        "jwt-decode": "^4.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.15.0",

--- a/frontend/src/pages/Dashboard/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard/Dashboard.jsx
@@ -3,11 +3,12 @@ import 'cesium/Build/Cesium/Widgets/widgets.css';
 import { Button } from '@components/Button/Button';
 import SatelliteIcon from '@assets/icons/satellite.svg?react';
 import './Dashboard.css';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { EntityPoint } from '@components/EntityPoint/EntityPoint';
 import { Card } from '@components/Card/Card';
 import { Ion } from 'cesium';
 import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
 
 Ion.defaultAccessToken = import.meta.env.VITE_ION_TOKEN;
 
@@ -16,7 +17,32 @@ export const Dashboard = () => {
     const [gcsCard, setGcsCard] = useState(false);
     const [lat, setLat] = useState(null);
     const [lng, setLng] = useState(null);
+    const [geoAttempted, setGeoAttempted] = useState(false);
     const wsRef = useRef(null);
+    const token = sessionStorage.getItem('token');
+    const user = token ? jwtDecode(token) : null;
+    const userId = user?.user_id;
+
+    const postJob = useCallback(
+        async (latitude, longitude) => {
+            // hard coded for Demo purposes only
+            const alt = 350;
+
+            await axios.post(
+                '/api/satellites/jobs',
+                {
+                    user_id: user.user_id,
+                    gcs: [{ lat: latitude, lng: longitude, alt }],
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                }
+            );
+        },
+        [user, token]
+    );
 
     useEffect(() => {
         const initializeGCSFromGeolocation = async () => {
@@ -32,9 +58,10 @@ export const Dashboard = () => {
 
                 return { lat, lng };
             } catch (err) {
-                if (err.code === 1) {
+                if (err.code === 1 && !geoAttempted) {
                     console.log('Permission denied');
                     setGcsCard(true);
+                    setGeoAttempted(true);
                 } else {
                     console.error(err);
                 }
@@ -42,26 +69,11 @@ export const Dashboard = () => {
         };
 
         const initialLog = async () => {
-            // hard coded for Demo purposes only
-            const user = () => {
-                // TODO: JWT set in prior auth/login page
-                // const token = localStorage.getItem('token');
-                // return = JSON.parse(atob(token.split('.')[1]));
-                return { userId: '1', hasLoggedIn: false };
-            };
-
-            const currentUser = user();
-
-            if (currentUser && !currentUser.hasLoggedIn) {
+            if (user && !user.hasLoggedIn) {
                 const coords = await initializeGCSFromGeolocation();
                 try {
                     if (coords) {
-                        // hard coded for Demo purposes only
-                        const alt = 350;
-                        await axios.post('/api/satellites/jobs', {
-                            userId: currentUser.userId,
-                            gcs: [{ lat: coords.lat, lng: coords.lng, alt }],
-                        });
+                        await postJob(coords.lat, coords.lng);
                     }
                 } catch (err) {
                     console.error(err);
@@ -73,9 +85,11 @@ export const Dashboard = () => {
     }, []);
 
     useEffect(() => {
-        if (wsRef.current) return;
-        // TODO: Grab userId from token
-        const socket = new WebSocket('ws://localhost:3000?userId=1');
+        if (!userId || wsRef.current) return;
+
+        const socket = new WebSocket(
+            `${import.meta.env.VITE_WS_URL}?user_id=${user.user_id}`
+        );
 
         wsRef.current = socket;
 
@@ -103,26 +117,13 @@ export const Dashboard = () => {
             socket.close();
             wsRef.current = null;
         };
-    }, []);
+    }, [userId]);
 
     const handleInitialGCS = (e) => {
         e.preventDefault();
-        // TODO: verify lat and lng coords
 
         (async () => {
-            // TODO: get userId from token
-            // hard coded for Demo purposes only
-            const userId = '1';
-            const alt = 350;
-
-            try {
-                await axios.post('/api/satellites/jobs', {
-                    userId,
-                    gcs: [{ lat, lng, alt }],
-                });
-            } catch (err) {
-                console.error(err);
-            }
+            await postJob(lat, lng);
         })();
         setGcsCard(false);
     };
@@ -172,7 +173,7 @@ export const Dashboard = () => {
                     return <EntityPoint key={sat.satid} {...satellite} />;
                 })}
             </Viewer>
-            {!satellites && (
+            {satellites.length === 0 && (
                 <div className='flex-container-center'>
                     <Card className='card card-error'>
                         No Satellites detected with given location and above

--- a/frontend/src/pages/Login/Login.jsx
+++ b/frontend/src/pages/Login/Login.jsx
@@ -23,7 +23,7 @@ export const Login = () => {
 
         try {
             const response = await axios.post(`/api/auth/login`, formData);
-            const token = response.token;
+            const token = response.data.token;
 
             sessionStorage.setItem('token', token);
 

--- a/frontend/src/pages/Register/Register.jsx
+++ b/frontend/src/pages/Register/Register.jsx
@@ -24,7 +24,7 @@ export const Register = () => {
 
         try {
             const response = await axios.post(`/api/auth/register`, formData);
-            const token = response.token;
+            const token = response.data.token;
 
             sessionStorage.setItem('token', token);
 


### PR DESCRIPTION
## Context

When a user registers for the first time, they need to immediately see satellites above their Ground Control Station (GCS) location. Previously the user_id was hard coded and then passed to the WebSocket connection established on the dashboard. 

## Summary

Implements a real-time WebSocket connection on the dashboard using the authenticated user's identity from their JWT. On first login, the user's geolocation is retrieved (if allowed else user inputs coordinates) and used to post an initial GCS job, which triggers a background worker that publishes satellite data over Redis. The backend Redis listener then pushes that data to the correct WebSocket client.

New functionality:
- WebSocket connection established on dashboard mount using user_id extracted from JWT in session storage
- Redis pub/sub listener (startRedisListener) forwards incoming messages to the correct connected WebSocket client
- WebSocket base URL stored in environment variable (VITE_WS_URL)


Modifications:
- app.js now awaits connectRedis() before calling startRedisListener() to prevent a race condition where subscribe() was called before the Redis connection was established 
- removeClient() now guards against deleting an entry that has already been overwritten by a newer socket

Refactoring:
Backend POST request encapsulated into shared postJob function via useCallback

Testing

Manual testing:

Registered a new user and confirmed geolocation prompt appears on first login
Confirmed satellite data is received over WebSocket and renders on the dashboard
Verified Redis logs show messages being received and forwarded to the correct client
Tested geolocation permission denial edge case — GCS manual input card appears as fallback


Edge cases considered:

React StrictMode double-mount causes two WebSocket connections for the same user_id in development — the second socket overwrites the first in the client map, and the delayed close event from the first socket was wiping the map entry. Fixed by only calling removeClient if the closing socket is still the currently registered one
Redis subscriber race condition — subscribe() was being called before the Redis client finished connecting, causing the listener to silently fail. Fixed by awaiting connectRedis() before startRedisListener()
Geolocation permission already denied on repeat visits — guarded with geoAttempted flag to prevent repeated prompts

## Related Issue

Closes #21 

## Checklist

- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [X] No breaking changes introduced
- [X] Linked related issue
